### PR TITLE
[master] Include Eloquent Model Database name in model:show command to distinguish between connection and database names

### DIFF
--- a/src/Illuminate/Foundation/Console/ShowModelCommand.php
+++ b/src/Illuminate/Foundation/Console/ShowModelCommand.php
@@ -103,6 +103,7 @@ class ShowModelCommand extends DatabaseInspectionCommand
             $model->getConnection()->getTablePrefix().$model->getTable(),
             $this->getAttributes($model),
             $this->getRelations($model),
+            $model->getConnection()->getDatabaseName(),
         );
     }
 
@@ -231,13 +232,14 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  string  $table
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
+     * @param string $databaseName
      * @return void
      */
-    protected function display($class, $database, $table, $attributes, $relations)
+    protected function display($class, $database, $table, $attributes, $relations, $databaseName)
     {
         $this->option('json')
-            ? $this->displayJson($class, $database, $table, $attributes, $relations)
-            : $this->displayCli($class, $database, $table, $attributes, $relations);
+            ? $this->displayJson($class, $database, $table, $attributes, $relations, $databaseName)
+            : $this->displayCli($class, $database, $table, $attributes, $relations, $databaseName);
     }
 
     /**
@@ -248,14 +250,16 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  string  $table
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
+     * @param string $databaseName
      * @return void
      */
-    protected function displayJson($class, $database, $table, $attributes, $relations)
+    protected function displayJson($class, $database, $table, $attributes, $relations, $databaseName)
     {
         $this->output->writeln(
             collect([
                 'class' => $class,
-                'database' => $database,
+                'connection' => $database,
+                'databaseName' => $databaseName,
                 'table' => $table,
                 'attributes' => $attributes,
                 'relations' => $relations,
@@ -271,14 +275,16 @@ class ShowModelCommand extends DatabaseInspectionCommand
      * @param  string  $table
      * @param  \Illuminate\Support\Collection  $attributes
      * @param  \Illuminate\Support\Collection  $relations
+     * @param string $databaseName
      * @return void
      */
-    protected function displayCli($class, $database, $table, $attributes, $relations)
+    protected function displayCli($class, $database, $table, $attributes, $relations, $databaseName)
     {
         $this->newLine();
 
         $this->components->twoColumnDetail('<fg=green;options=bold>'.$class.'</>');
-        $this->components->twoColumnDetail('Database', $database);
+        $this->components->twoColumnDetail('Connection', $database);
+        $this->components->twoColumnDetail('DatabaseName', $databaseName);
         $this->components->twoColumnDetail('Table', $table);
 
         $this->newLine();


### PR DESCRIPTION
This PR builds on the new `artisan model:show` command to show the database name of the Model. It could be handy to see on the Model information as it's not always obvious the name of the database of a Model.

It handles cases where multiple databases connection are used.

_________

It is originally called the connection name as database, see bellow.
![image](https://user-images.githubusercontent.com/34031333/202366535-24bf9654-ea99-4fb6-bdfc-aa550ffe4a8d.png)

But this PR is differentiate between database name and connection name
![image](https://user-images.githubusercontent.com/34031333/202368315-3e9161d6-aac4-4f6f-bc5f-b76065003e69.png)

